### PR TITLE
Allow the api name to appear in tags instead of the metric name

### DIFF
--- a/kong/plugins/datadog/schema.lua
+++ b/kong/plugins/datadog/schema.lua
@@ -198,5 +198,9 @@ return {
       type     = "string",
       default  = "kong",
     },
+    tag_api_name = {
+      type     = "boolean",
+      default  = false,
+    },
   }
 }


### PR DESCRIPTION
### Summary

Data dog prefers to use tags to query and divide statistics up by.
By putting the api name in the key, we cannot create dashboards that
are keyed off the api name. This is accomplished via a new plugin
setting called `tag_api_name`. It is a boolean field that when set
to true will remove the api_name from the metric key and add it as
a tag. It will append this tag to whatever tags are defined by the
metric configuration.

### Full changelog

* Implemented schema changes
* Implemented test for api name inclusion in key set
* Implemented appended api name to key set
* Refactored plugin to help readability.

