### PR TITLE
feat(datadog) Allow the api name to appear in tags instead of the metric name

### DIFF
--- a/kong/plugins/datadog/handler.lua
+++ b/kong/plugins/datadog/handler.lua
@@ -25,59 +25,52 @@ local get_consumer_id = {
   end,
   username    = function(consumer)
     return consumer and consumer.username
-  end
+  end,
 }
 
 
 local metrics = {
-  status_count = function (api_name, message, metric_config, logger)
-    local fmt = string_format("%s.request.status", api_name,
-                       message.response.status)
+  status_count = function(name_prefix, message, metric_config, logger, tags)
+    local fmt = string_format("%srequest.status", name_prefix, message.response.status)
 
     logger:send_statsd(string_format("%s.%s", fmt, message.response.status),
-                       1, logger.stat_types.counter,
-                       metric_config.sample_rate, metric_config.tags)
+                       1, logger.stat_types.counter, metric_config.sample_rate, tags)
 
     logger:send_statsd(string_format("%s.%s", fmt, "total"), 1,
-                       logger.stat_types.counter,
-                       metric_config.sample_rate, metric_config.tags)
+                       logger.stat_types.counter, metric_config.sample_rate, tags)
   end,
-  unique_users = function (api_name, message, metric_config, logger)
+
+  unique_users = function(name_prefix, message, metric_config, logger, tags)
     local get_consumer_id = get_consumer_id[metric_config.consumer_identifier]
-    local consumer_id     = get_consumer_id(message.consumer)
-
+    local consumer_id = get_consumer_id(message.consumer)
     if consumer_id then
-      local stat = string_format("%s.user.uniques", api_name)
-
-      logger:send_statsd(stat, consumer_id, logger.stat_types.set,
-                         nil, metric_config.tags)
+      local stat = string_format("%suser.uniques", name_prefix)
+      logger:send_statsd(stat, consumer_id, logger.stat_types.set, nil, tags)
     end
   end,
-  request_per_user = function (api_name, message, metric_config, logger)
+
+  request_per_user = function(name_prefix, message, metric_config, logger, tags)
     local get_consumer_id = get_consumer_id[metric_config.consumer_identifier]
-    local consumer_id     = get_consumer_id(message.consumer)
+    local consumer_id = get_consumer_id(message.consumer)
 
     if consumer_id then
-      local stat = string_format("%s.user.%s.request.count", api_name, consumer_id)
-
-      logger:send_statsd(stat, 1, logger.stat_types.counter,
-                         metric_config.sample_rate, metric_config.tags)
+      local stat = string_format("%suser.%s.request.count", name_prefix, consumer_id)
+      logger:send_statsd(stat, 1, logger.stat_types.counter, metric_config.sample_rate, tags)
     end
   end,
-  status_count_per_user = function (api_name, message, metric_config, logger)
+
+  status_count_per_user = function(name_prefix, message, metric_config, logger, tags)
     local get_consumer_id = get_consumer_id[metric_config.consumer_identifier]
-    local consumer_id     = get_consumer_id(message.consumer)
+    local consumer_id = get_consumer_id(message.consumer)
 
     if consumer_id then
-      local fmt = string_format("%s.user.%s.request.status", api_name, consumer_id)
+      local fmt = string_format("%suser.%s.request.status", name_prefix, consumer_id)
 
       logger:send_statsd(string_format("%s.%s", fmt, message.response.status),
-                         1, logger.stat_types.counter,
-                         metric_config.sample_rate, metric_config.tags)
+                         1, logger.stat_types.counter, metric_config.sample_rate, tags)
 
-      logger:send_statsd(string_format("%s.%s", fmt,  "total"),
-                         1, logger.stat_types.counter,
-                         metric_config.sample_rate, metric_config.tags)
+      logger:send_statsd(string_format("%s.%s", fmt, "total"),
+                         1, logger.stat_types.counter, metric_config.sample_rate, tags)
     end
   end,
 }
@@ -88,16 +81,23 @@ local function log(premature, conf, message)
     return
   end
 
-  local api_name   = string_gsub(message.api.name, "%.", "_")
-  local stat_name  = {
-    request_size     = api_name .. ".request.size",
-    response_size    = api_name .. ".response.size",
-    latency          = api_name .. ".latency",
-    upstream_latency = api_name .. ".upstream_latency",
-    kong_latency     = api_name .. ".kong_latency",
-    request_count    = api_name .. ".request.count",
+  local logger, err = statsd_logger:new(conf)
+  if err then
+    ngx_log(NGX_ERR, "failed to create Statsd logger: ", err)
+    return
+  end
+
+  local api_name    = string_gsub(message.api.name, "%.", "_")
+  local name_prefix = conf.tag_api_name and "" or api_name .. "."
+  local stat_name   = {
+    request_size     = name_prefix .. "request.size",
+    response_size    = name_prefix .. "response.size",
+    latency          = name_prefix .. "latency",
+    upstream_latency = name_prefix .. "upstream_latency",
+    kong_latency     = name_prefix .. "kong_latency",
+    request_count    = name_prefix .. "request.count",
   }
-  local stat_value = {
+  local stat_value  = {
     request_size     = message.request.size,
     response_size    = message.response.size,
     latency          = message.latencies.request,
@@ -106,25 +106,23 @@ local function log(premature, conf, message)
     request_count    = 1,
   }
 
-  local logger, err = statsd_logger:new(conf)
-  if err then
-    ngx_log(NGX_ERR, "failed to create Statsd logger: ", err)
-    return
-  end
-
   for _, metric_config in pairs(conf.metrics) do
-    local metric = metrics[metric_config.name]
+    local metric_func = metrics[metric_config.name]
 
-    if metric then
-      metric(api_name, message, metric_config, logger)
+    local tags = metric_config.tags or {}
+    if conf.tag_api_name then
+      table.insert(tags, "api_name:" .. api_name)
+    end
 
+    if metric_func then
+      metric_func(name_prefix, message, metric_config, logger, tags)
     else
       local stat_name  = stat_name[metric_config.name]
       local stat_value = stat_value[metric_config.name]
 
       logger:send_statsd(stat_name, stat_value,
                          logger.stat_types[metric_config.stat_type],
-                         metric_config.sample_rate, metric_config.tags)
+                         metric_config.sample_rate, tags)
     end
   end
 
@@ -135,6 +133,7 @@ end
 function DatadogHandler:new()
   DatadogHandler.super.new(self, "datadog")
 end
+
 
 function DatadogHandler:log(conf)
   DatadogHandler.super.log(self)
@@ -151,5 +150,6 @@ function DatadogHandler:log(conf)
     ngx_log(NGX_ERR, "failed to create timer: ", err)
   end
 end
+
 
 return DatadogHandler

--- a/kong/plugins/datadog/schema.lua
+++ b/kong/plugins/datadog/schema.lua
@@ -198,5 +198,9 @@ return {
       type     = "string",
       default  = "kong",
     },
+    tag_api_name = {
+      type     = "boolean",
+      default  = false,
+    },
   }
 }

--- a/spec/03-plugins/08-datadog/01-log_spec.lua
+++ b/spec/03-plugins/08-datadog/01-log_spec.lua
@@ -40,6 +40,11 @@ describe("Plugin: datadog (log)", function()
       hosts        = { "datadog4.com" },
       upstream_url = helpers.mock_upstream_url,
     })
+    local api5     = assert(helpers.dao.apis:insert {
+      name         = "dd5",
+      hosts        = { "datadog5.com" },
+      upstream_url = helpers.mock_upstream_url,
+    })
     assert(helpers.dao.plugins:insert {
       name   = "key-auth",
       api_id = api4.id
@@ -107,6 +112,28 @@ describe("Plugin: datadog (log)", function()
         host   = "127.0.0.1",
         port   = 9999,
         prefix = "prefix",
+      },
+    })
+    assert(helpers.dao.plugins:insert {
+      name   = "datadog",
+      api_id = api5.id,
+      config = {
+        host          = "127.0.0.1",
+        port          = 9999,
+        tag_api_name  = true,
+        metrics = {
+          {
+            name        = "status_count",
+            stat_type   = "counter",
+            sample_rate = 1,
+          },
+          {
+            name        = "latency",
+            stat_type   = "gauge",
+            sample_rate = 1,
+            tags        = {"T2:V2:V3,T4"},
+          },
+        },
       },
     })
 
@@ -285,6 +312,41 @@ describe("Plugin: datadog (log)", function()
     assert.contains("kong.dd3.request.status.200:1|c|#T1:V1", gauges)
     assert.contains("kong.dd3.request.status.total:1|c|#T1:V1", gauges)
     assert.contains("kong.dd3.latency:%d+|g|#T2:V2:V3,T4", gauges, true)
+  end)
+
+  it("logs metrics with tags with api name in tag", function()
+    local thread = threads.new({
+      function()
+        local socket = require "socket"
+        local server = assert(socket.udp())
+        server:settimeout(1)
+        server:setoption("reuseaddr", true)
+        server:setsockname("127.0.0.1", 9999)
+        local gauges = {}
+        for _ = 1, 3 do
+          gauges[#gauges+1] = server:receive()
+        end
+        server:close()
+        return gauges
+      end
+    })
+    thread:start()
+
+    local res = assert(client:send {
+      method = "GET",
+      path = "/status/200",
+      headers = {
+        ["Host"] = "datadog5.com"
+      }
+    })
+    assert.res_status(200, res)
+
+    local ok, gauges = thread:join()
+    assert.True(ok)
+    assert.equal(3, #gauges)
+    assert.contains("kong.request.status.200:1|c|#api_name:dd5", gauges)
+    assert.contains("kong.request.status.total:1|c|#api_name:dd5", gauges)
+    assert.contains("kong.latency:%d+|g|#T2:V2:V3,T4,api_name:dd5", gauges, true)
   end)
 
   it("should not return a runtime error (regression)", function()


### PR DESCRIPTION
Data dog prefers to use tags to query and divide statistics up by.
By putting the api name in the key, we cannot create dashboards that
are keyed off the api name. This is accomplished via a new plugin
setting called `tag_api_name`. It is a boolean field that when set
to true will remove the api_name from the metric key and add it as
a tag. It will append this tag to whatever tags are defined by the
metric configuration.
